### PR TITLE
add monthly summary test cases

### DIFF
--- a/src/main/kotlin/test/TestCases.kt
+++ b/src/main/kotlin/test/TestCases.kt
@@ -1,5 +1,10 @@
 package test
 
+import models.Category
+import models.Transaction
+import models.TransactionType
+import java.time.LocalDate
+
 
 fun main(){
 //region Transactions Test Cases
@@ -16,6 +21,86 @@ fun main(){
 //todo: write all test cases that related with Report here :)
 
 //endregion
+
+
+//region Monthly Summary Test Cases
+
+    fun getMonthlySummary(year:Int, month:Int,transactions:List<Transaction> ):MonthlySummaryResult{
+        return MonthlySummaryResult.NoTransactions
+    }
+
+
+    fun checkMonthlySummary(testName: String, result: MonthlySummaryResult, expected: MonthlySummaryResult) {
+        val passed = when {
+            result is MonthlySummaryResult.Error && expected is MonthlySummaryResult.Error ->
+                result.errorMessage == expected.errorMessage
+            result is MonthlySummaryResult.NoTransactions && expected is MonthlySummaryResult.NoTransactions -> true
+            result is MonthlySummaryResult.Success && expected is MonthlySummaryResult.Success ->
+                result.transactions == expected.transactions
+            else -> false
+        }
+
+        if (passed) {
+            println("Success - $testName")
+        } else {
+            println("Failed - $testName")
+        }
+    }
+
+
+    val carCategory = Category(id = 1, name = "car")
+    val salaryCategory = Category(id = 1, name = "salary")
+    val rentCategory = Category(id = 1, name = "rent")
+
+    val testTransactions = listOf(
+        Transaction(1, 5000.0, "Salary", LocalDate.of(2023,6,1), salaryCategory, TransactionType.INCOME),
+        Transaction(2, 200.0, "fuel", LocalDate.of(2023,6,5), carCategory, TransactionType.EXPENSE),
+        Transaction(3, 1000.0, "Rent", LocalDate.of(2023,5,1), rentCategory, TransactionType.EXPENSE)
+    )
+
+    checkMonthlySummary(
+        "when no transactions in month should return NoTransactions",
+        getMonthlySummary(2023, 7, testTransactions),
+        MonthlySummaryResult.NoTransactions
+    )
+
+    checkMonthlySummary(
+        "when year is after now should return error",
+        getMonthlySummary(LocalDate.now().year + 1, 6, testTransactions),
+        MonthlySummaryResult.Error("Cannot view summary for future years")
+    )
+
+    checkMonthlySummary(
+        "when month is after current month in current year should return error",
+        getMonthlySummary(LocalDate.now().year, LocalDate.now().monthValue + 1, testTransactions),
+        MonthlySummaryResult.Error("Cannot view summary for future months")
+    )
+
+    checkMonthlySummary(
+        "when month number is invalid should return error",
+        getMonthlySummary(2023, 13, testTransactions),
+        MonthlySummaryResult.Error("Month must be between 1 and 12")
+    )
+
+    checkMonthlySummary(
+        "when year number is invalid should return error",
+        getMonthlySummary(-2023, 6, testTransactions),
+        MonthlySummaryResult.Error("Year must be positive")
+    )
+
+    checkMonthlySummary(
+        "when valid month with transactions should return correct summary",
+        getMonthlySummary(2023, 6, testTransactions),
+        MonthlySummaryResult.Success(listOf(
+            Transaction(1, 5000.0, "Salary", LocalDate.of(2023,6,1), salaryCategory, TransactionType.INCOME),
+            Transaction(2, 200.0, "fuel", LocalDate.of(2023,6,5), carCategory, TransactionType.EXPENSE)
+        ))
+    )
+
+
+
+
+//endregion
 }
 
 fun check(testName: String, result: Boolean, acceptedResult: Boolean){
@@ -24,4 +109,14 @@ fun check(testName: String, result: Boolean, acceptedResult: Boolean){
     } else{
         println("Failed - $testName")
     }
+}
+
+
+
+
+//temp class for testing
+sealed class MonthlySummaryResult {
+    data class Error(val errorMessage: String) : MonthlySummaryResult()
+    object NoTransactions : MonthlySummaryResult()
+    data class Success(val transactions: List<Transaction>) : MonthlySummaryResult()
 }

--- a/src/main/kotlin/test/TestCases.kt
+++ b/src/main/kotlin/test/TestCases.kt
@@ -1,10 +1,5 @@
 package test
 
-import models.Category
-import models.Transaction
-import models.TransactionType
-import java.time.LocalDate
-
 
 fun main(){
 
@@ -78,80 +73,12 @@ fun main(){
 
 //region Monthly Summary Test Cases
 
-    fun getMonthlySummary(year:Int, month:Int,transactions:List<Transaction> ):MonthlySummaryResult{
-        return MonthlySummaryResult.NoTransactions
-    }
-
-
-    fun checkMonthlySummary(testName: String, result: MonthlySummaryResult, expected: MonthlySummaryResult) {
-        val passed = when {
-            result is MonthlySummaryResult.Error && expected is MonthlySummaryResult.Error ->
-                result.errorMessage == expected.errorMessage
-            result is MonthlySummaryResult.NoTransactions && expected is MonthlySummaryResult.NoTransactions -> true
-            result is MonthlySummaryResult.Success && expected is MonthlySummaryResult.Success ->
-                result.transactions == expected.transactions
-            else -> false
-        }
-
-        if (passed) {
-            println("Success - $testName")
-        } else {
-            println("Failed - $testName")
-        }
-    }
-
-
-    val carCategory = Category(id = 1, name = "car")
-    val salaryCategory = Category(id = 1, name = "salary")
-    val rentCategory = Category(id = 1, name = "rent")
-
-    val testTransactions = listOf(
-        Transaction(1, 5000.0, "Salary", LocalDate.of(2023,6,1), salaryCategory, TransactionType.INCOME),
-        Transaction(2, 200.0, "fuel", LocalDate.of(2023,6,5), carCategory, TransactionType.EXPENSE),
-        Transaction(3, 1000.0, "Rent", LocalDate.of(2023,5,1), rentCategory, TransactionType.EXPENSE)
-    )
-
-    checkMonthlySummary(
-        "when no transactions in month should return NoTransactions",
-        getMonthlySummary(2023, 7, testTransactions),
-        MonthlySummaryResult.NoTransactions
-    )
-
-    checkMonthlySummary(
-        "when year is after now should return error",
-        getMonthlySummary(LocalDate.now().year + 1, 6, testTransactions),
-        MonthlySummaryResult.Error("Cannot view summary for future years")
-    )
-
-    checkMonthlySummary(
-        "when month is after current month in current year should return error",
-        getMonthlySummary(LocalDate.now().year, LocalDate.now().monthValue + 1, testTransactions),
-        MonthlySummaryResult.Error("Cannot view summary for future months")
-    )
-
-    checkMonthlySummary(
-        "when month number is invalid should return error",
-        getMonthlySummary(2023, 13, testTransactions),
-        MonthlySummaryResult.Error("Month must be between 1 and 12")
-    )
-
-    checkMonthlySummary(
-        "when year number is invalid should return error",
-        getMonthlySummary(-2023, 6, testTransactions),
-        MonthlySummaryResult.Error("Year must be positive")
-    )
-
-    checkMonthlySummary(
-        "when valid month with transactions should return correct summary",
-        getMonthlySummary(2023, 6, testTransactions),
-        MonthlySummaryResult.Success(listOf(
-            Transaction(1, 5000.0, "Salary", LocalDate.of(2023,6,1), salaryCategory, TransactionType.INCOME),
-            Transaction(2, 200.0, "fuel", LocalDate.of(2023,6,5), carCategory, TransactionType.EXPENSE)
-        ))
-    )
-
-
-
+    check(testName = "when no transactions in month should return NoTransactions", result = false, acceptedResult = false)
+    check(testName = "when year is after now should return error", result = false, acceptedResult = false)
+    check(testName = "when month is after current month in current year should return error", result = false, acceptedResult = false)
+    check(testName = "when month number is invalid should return error", result = false, acceptedResult = false)
+    check(testName = "when year number is invalid should return error", result = false, acceptedResult = false)
+    check(testName = "when valid month with transactions should return correct summary", result = false, acceptedResult = false)
 
 //endregion
 }
@@ -162,14 +89,4 @@ fun check(testName: String, result: Boolean, acceptedResult: Boolean){
     } else{
         println("Failed - $testName")
     }
-}
-
-
-
-
-//temp class for testing
-sealed class MonthlySummaryResult {
-    data class Error(val errorMessage: String) : MonthlySummaryResult()
-    object NoTransactions : MonthlySummaryResult()
-    data class Success(val transactions: List<Transaction>) : MonthlySummaryResult()
 }


### PR DESCRIPTION
add complete test for monthly summary feature

- Add tests for all error cases (years or months after now )
- Add tests for empty transactions month scenario
- Add tests for successful cases with transactions